### PR TITLE
Ignore folders

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -11,7 +11,13 @@ credentials:
 
     # The place where files get safed
     base_path : "ilias"
-    
+
+    # Folder names which should be ignored
+    # NOTE: Do not look at the folder name in ilias! Instead look at the one on your hard drive!
+    blacklisted_folders :
+        - "Folder_1"
+        - "Folder_2"
+
     # Dont get to crazy here
     num_threads : 4
 

--- a/ilias_downloader.py
+++ b/ilias_downloader.py
@@ -29,6 +29,8 @@ url = cfg["credentials"]["url"]
 
 base_path = f"{PATH}/" + cfg["credentials"]["base_path"]
 
+blacklisted_folders = cfg["credentials"]["blacklisted_folders"]
+
 login_url = cfg["credentials"]["login_url"]
 uname = cfg["credentials"]["uname"]
 password = cfg["credentials"]["password"]
@@ -69,7 +71,13 @@ def crawl_url(q, browser, cj):
 
     global seen_urls
 
-    if next_url in seen_urls:
+    # Subtract base_path of path and get a list of remaining folders
+    folders = path.replace(base_path, '').split("/")
+
+    # Check if both lists overlap
+    if bool(set(blacklisted_folders) & set(folders)):
+        print(f"Skipping {path} - Folder is blacklisted.")
+    elif next_url in seen_urls:
         print(f"Skipping {next_url}. already seen")
     else:
 


### PR DESCRIPTION
Added a new parameter blacklisted_folders inside the config.
When filling the list with strings e.g. "Subject XYZ WS20/21" the
script will ignore this folder during crawling.